### PR TITLE
CRDL-383 Update the acceptance tests to expect the original Not Found behaviour

### DIFF
--- a/src/test/scala/uk/gov/hmrc/api/specs/ImportRefDataAPISpec.scala
+++ b/src/test/scala/uk/gov/hmrc/api/specs/ImportRefDataAPISpec.scala
@@ -328,7 +328,6 @@ class ImportRefDataAPISpec extends BaseSpec, HttpClient, BeforeAndAfterAll:
 
       val authToken       = fetchAuthToken(): String
       val refDataResponse = fetchRefData(authToken, "oracle/epc-codes")
-      refDataResponse.status        shouldBe 200
-      refDataResponse.body[JsValue] shouldBe Json.arr()
+      refDataResponse.status shouldBe 404
     }
   }


### PR DESCRIPTION
The original emcs-tfe-reference-data service would return 404 Not Found from the `/epc-codes` endpoint when the stored procedures returned no data.

We restored this original behaviour in hmrc/emcs-tfe-crdl-reference-data#13 and this change updates the acceptance tests to reflect that.